### PR TITLE
Notify correct condition variable

### DIFF
--- a/Chapter_04/mutex_queue.h
+++ b/Chapter_04/mutex_queue.h
@@ -62,7 +62,7 @@ class queue {
 
         lock.unlock();
 
-        not_empty_.notify_one();
+        not_full_.notify_one();
 
         return true;
     }


### PR DESCRIPTION
I believe `try_pop` should notify the `not_full_` CV like it does in the implementation of `pop`