### PR TITLE
Update 9x10-single_io_context_several_handlers_thread.cpp

### DIFF
--- a/Chapter_09/9x10-single_io_context_several_handlers_thread.cpp
+++ b/Chapter_09/9x10-single_io_context_several_handlers_thread.cpp
@@ -23,10 +23,9 @@ int main() {
 
     std::jthread io_context_thread([&io_context]() { io_context.run(); });
 
-    const int num_threads = 4;
-    std::vector<std::jthread> threads;
+    const int num_threads = 4;    
     for (int i = 0; i < num_threads; ++i) {
-        background_task(i);
+        background_task(i);//io_context_thread will pick up the posted tasks
     }
 
     std::this_thread::sleep_for(5s);


### PR DESCRIPTION
> std::vector\<std::jthread\> threads;

 seems useless and misleading. You don't know if you want to post throw a thread workpool or not.